### PR TITLE
Load note on browser back

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -16,13 +16,19 @@ module Api
     end
 
     def show
-      @note = Note.find_by!(uid: params[:id])
+      @note = Note.find_by(uid: params[:id])
 
-      authorize @note
+      if @note
+        authorize @note
 
-      render json: {
-        note: @note
-      }
+        render json: {
+          note: @note
+        }
+      else
+        skip_authorization
+
+        render json: {}, status: :not_found
+      end
     end
 
     def update

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AuthenticatedController < ApplicationController
-  include Pundit
+  include Pundit::Authorization
 
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit

--- a/client/src/Note.js
+++ b/client/src/Note.js
@@ -56,6 +56,8 @@ class Note {
   }
 
   static fromAttributes(attributes) {
+    if (!attributes) return;
+
     return new Note(
       attributes.uid,
       attributes.title,

--- a/client/src/NoteEdit.svelte
+++ b/client/src/NoteEdit.svelte
@@ -146,12 +146,12 @@
       const data = await ajax(`/api/notes/${id}`)
       note = Note.fromAttributes(data.note)
     } catch (error) {
+      setNew()
       show('alert',
         'While trying to load the note the internet broke down (or something ' +
           'else failed, maybe the note could not be found)'
       )
     }
-
   }
 
   const handleNoteClick = (event) => {

--- a/client/src/NoteEdit.svelte
+++ b/client/src/NoteEdit.svelte
@@ -64,7 +64,6 @@
   let autoSave
   let isSynced
   let listNeedsUpdate
-  let noteCreateSubscription
   let noteNewSubscription
   let searchEnteredSubscription
   let searchClearedSubscription
@@ -75,12 +74,6 @@
 
 
   onMount(() => {
-    noteCreateSubscription = EventHive.subscribe('note.create', (data) => {
-      setNewNote(() => {
-        EventHive.publish('note.update', data)
-      })
-    })
-
     noteNewSubscription = EventHive.subscribe('note.new', (data) => {
       setNewNote()
     })
@@ -140,7 +133,6 @@
   })
 
   onDestroy(() => {
-    noteCreateSubscription.remove()
     noteNewSubscription.remove()
     autoSave.stopPolling()
   })

--- a/client/src/NoteEdit.svelte
+++ b/client/src/NoteEdit.svelte
@@ -135,6 +135,8 @@
       note = new Note()
       showList = true
     }
+
+    setBrowserTitle(note)
   })
 
   onDestroy(() => {
@@ -151,7 +153,6 @@
     try {
       const data = await ajax(`/api/notes/${id}`)
       note = Note.fromAttributes(data.note)
-      setBrowserTitle(note)
     } catch (error) {
       show('alert',
         'While trying to load the note the internet broke down (or something ' +
@@ -166,7 +167,6 @@
 
     showList = false
     setEdit(event.detail)
-    setBrowserTitle(event.detail)
   }
 
   const handleDeleteNoteClick = (e) => {
@@ -224,17 +224,12 @@
     if (data.note && note.uid === data.note.uid) {
       note.serverUpdatedAt = data.note.serverUpdatedAt
     }
-
-    if (data.isSynced) {
-      setBrowserTitle(note)
-    }
   }
 
   const setNewNote = (callback) => {
     showList = false
     if (callback) callback()
     setNew()
-    setBrowserTitle()
   }
 
   const deleteNote = (affectedNote) => {

--- a/client/src/NoteForm.svelte
+++ b/client/src/NoteForm.svelte
@@ -19,6 +19,7 @@
   import { createEventDispatcher, onMount, onDestroy, afterUpdate } from 'svelte'
   import './highlight.js'
   import Quill from 'quill'
+  import { searchTerm } from './stores'
   import 'quill-task-list/task_list_node'
   import 'quill/dist/quill.snow.css'
   import EventHive from './EventHive'
@@ -80,7 +81,7 @@
   }
 
   const focusTitleFieldIfNewNote = () => {
-    if (note.isNew()) {
+    if (note.isNew() && !$searchTerm) {
       setTimeout(() => titleElement.focus(), 100)
     }
   }

--- a/client/src/NoteList.svelte
+++ b/client/src/NoteList.svelte
@@ -10,10 +10,10 @@
     </div>
   {/if}
 
-  {#if $searchTerm && notes.length === 0}
+  {#if $searchTerm && $notes.length === 0}
     <div>There's nothing…</div>
   {:else}
-    {#each notes as note}
+    {#each $notes as note}
       <div
         class="card list-item"
         class:active={note.uid === activeNoteUid}
@@ -67,6 +67,7 @@
   import NotePicture from './NotePicture.svelte'
   import ArchiveIcon from './icons/material/archive-24px.svg.svelte'
   import DeleteIcon from './icons/material/delete-24px.svg.svelte'
+  import { notes } from './stores.js'
 
   export let activeNoteUid
   export let isSynced
@@ -75,7 +76,6 @@
   export let listNeedsUpdate
   export let collection
 
-  let notes = []
   let currentPage = 1
   let hasMorePages = false
   let isLoadingMorePages = true
@@ -141,7 +141,7 @@
   const executeUpdateListRequest = () => {
     updateListRequest.promise
       .then((data) => {
-        notes = data.notes.map((note) => {
+        $notes = data.notes.map((note) => {
           return Note.fromAttributes(note)
         })
 

--- a/client/src/SyncStorage.js
+++ b/client/src/SyncStorage.js
@@ -14,6 +14,13 @@ class SyncStorage {
     return localStorage.getItem(SyncStorage._getKey(note));
   }
 
+  static getJson(note) {
+    note = SyncStorage.get(note)
+    if (note) {
+      return JSON.parse(note)
+    }
+  }
+
   static eachNote(callback) {
     const keys = SyncStorage._getLocalStorageKeys();
 

--- a/client/src/stores.js
+++ b/client/src/stores.js
@@ -3,3 +3,5 @@ import { writable } from 'svelte/store'
 export const isAuthenticated = writable(undefined)
 
 export const searchTerm = writable('')
+
+export const notes = writable([])


### PR DESCRIPTION
The pushstate currently works, i.e. the URL is updated on browser back. The note though doesn't change back. There's a discrepancy between the URL and the actual shown note.

The browser back behaviour of the mobile view will be changed in a follow-up. There the behaviour should be that browser back on a note should go back to the list.


> The browser back button, and especially the back button on mobile (in the PWA) did change the url so far, but didn't show the note. The note is now properly loaded on browser back.
>
> For this to work the loaded notes are stored in a svelte store. When navigating back, the note is tried in 3 different places:
>
> 1. From the sync storage, in case there are locale changes
> 2. From the $notes svelte store
> 3. From the server

---

TODO:

- [x] `await ajax` catch doesn't work, e.g. 404 goes to `handleThen`.