### PR TITLE
Prevent cursor jump in content on title change

### DIFF
--- a/client/src/NoteForm.svelte
+++ b/client/src/NoteForm.svelte
@@ -31,7 +31,7 @@
   let contentElement
 
   const handleTitleChange = () => {
-    shouldRerender = true
+    shouldRerender = false
     note.title = titleElement.value
     dispatch('change', note)    
   }

--- a/client/src/NoteForm.svelte
+++ b/client/src/NoteForm.svelte
@@ -1,18 +1,13 @@
 <div class:hidden-sm={!showForm}>
-  <form
-    bind:this={formContainerElement}
-    on:submit={handleFormSubmit}>
+  <input
+    type="text"
+    value={note.title}
+    on:input={handleTitleChange}
+    placeholder="Title"
+    bind:this={titleElement}
+  />
 
-    <input
-      type="text"
-      value={note.title}
-      on:input={handleTitleChange}
-      placeholder="Title"
-      bind:this={titleElement}
-    />
-
-    <div bind:this={contentContainerElement}></div>
-  </form>
+  <div bind:this={contentContainerElement}></div>
 </div>
 
 <script>
@@ -31,17 +26,9 @@
 
   let shouldRerender = true
   let editor
-  let formContainerElement
   let titleElement
   let contentContainerElement
   let contentElement
-
-  // prevent form submission by hitting enter.
-  // changes will be asynchronously saved by ajax.
-  const handleFormSubmit = (e) => {
-    e.preventDefault()
-    return false
-  }
 
   const handleTitleChange = () => {
     shouldRerender = true


### PR DESCRIPTION
When the title is changed and the user edits the content before the save cycle, the cursor jumps to the beginning of the content after saving.

`shouldRerender` was previously explicitly set to `true` on title change. I'm can't recall / reproduce why it was that way. Let's try with no rerender and hope for the best.