### PR TITLE
fix "share to"

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,20 +1,20 @@
-self.addEventListener('fetch', (fetchEvent) => {
-  if (fetchEvent.request.url.endsWith('/share-target/') && fetchEvent.request.method === 'POST') {
-    return fetchEvent.respondWith(
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.endsWith('/share-target/') && event.request.method === 'POST') {
+    return event.respondWith(
       (async () => {
-        const formData = await fetchEvent.request.formData();
+        const formData = await event.request.formData();
         const image = formData.get('image');
         const title = formData.get('title');
         const text = formData.get('text');
         const url = formData.get('url');
 
         const keys = await caches.keys();
-        const mediaCache = await caches.open(keys.filter((key) => key.startsWith('media'))[0]);
+        const cache = await caches.open('media');
 
         if (image) {
-          await mediaCache.put('shared-image', new Response(image));
+          await cache.put('shared-image', new Response(image));
         } else {
-          await mediaCache.put('shared-data', new Response(JSON.stringify({ title, text, url })));
+          await cache.put('shared-data', new Response(JSON.stringify({ title, text, url })));
         }
         return Response.redirect('/#/notes?share-target', 303);
       })(),

--- a/client/src/NoteEdit.svelte
+++ b/client/src/NoteEdit.svelte
@@ -87,22 +87,7 @@
       autoSave.startPolling()
     }
 
-    if (!params.id) {
-      note = new Note()
-    }
-    else if (params.id && note?.uid !== params.id) {
-      // 1. try sync storage
-      note = Note.fromAttributes(SyncStorage.getJson({ uid: params.id }))
-      if (!note) {
-        // 2. try svelte store
-        note = $notes.find(note => note.uid === params.id)
-        if (!note) {
-          // 3. try server
-          await initStateFromNoteId(params.id)
-        }
-      }
-    }
-    else if ($querystring.includes('share-target')) {
+    if ($querystring.includes('share-target')) {
       note = new Note()
 
       const blob = await getBlob('shared-image')
@@ -119,8 +104,24 @@
           note.content = [json.text, json.url].filter(x => x).join('<br/>')
         }
 
+        showList = false
         setEdit(note)
         autoSave.setChange(note)
+      }
+    }
+    else if (!params.id) {
+      note = new Note()
+    }
+    else if (params.id && note?.uid !== params.id) {
+      // 1. try sync storage
+      note = Note.fromAttributes(SyncStorage.getJson({ uid: params.id }))
+      if (!note) {
+        // 2. try svelte store
+        note = $notes.find(note => note.uid === params.id)
+        if (!note) {
+          // 3. try server
+          await initStateFromNoteId(params.id)
+        }
       }
     }
 

--- a/client/src/cache.js
+++ b/client/src/cache.js
@@ -1,13 +1,11 @@
 export async function getBlob(name) {
   const keys = await caches.keys()
-  const mediaCache = await caches.open(
-    keys.filter((key) => key.startsWith('media'))[0],
-  )
+  const cache = await caches.open('media')
 
-  const image = await mediaCache.match(name)
+  const image = await cache.match(name)
   if (image) {
     const blob = await image.blob()
-    await mediaCache.delete(name)
+    await cache.delete(name)
 
     return blob
   }
@@ -15,14 +13,12 @@ export async function getBlob(name) {
 
 export async function getJson(name) {
   const keys = await caches.keys()
-  const mediaCache = await caches.open(
-    keys.filter((key) => key.startsWith('media'))[0],
-  )
+  const cache = await caches.open('media')
 
-  const data = await mediaCache.match(name)
+  const data = await cache.match(name)
   if (data) {
     const json = await data.json()
-    await mediaCache.delete(name)
+    await cache.delete(name)
 
     return json
   }


### PR DESCRIPTION
### 1. Fix share to by not skipping the case in `NoteEdit`

Share to didn't work anymore. The first `if` (`!params.id`) always took precedence, and therefore the code matching the `share-target` url queryparam was never executed.

There was also some kind of weirdness around the cache key being `"undefined"`. According to
https://github.com/GoogleChrome/samples/blob/gh-pages/web-share/src/js/service-worker.js which is referenced by
https://developer.chrome.com/articles/web-share-target/#sample-applications the whole `find` stuff around the cache key doesn't seem necessary. We apparently can just use the static cache key.

### 2. Fix share by not creating multiple notes

The current handling of initializing the `NoteEdit` component by relying on `#beforeUpdate` is flawed. That function gets triggered too many times. Every change to a variable that affects the component or any child component will fire that event. To initialize from `share-target` this is especially problematic, since it will create multiple notes from the provided data.

We now change the whole thing to rely on reactive statements instead. This is much more robust since we can rely on those triggering only when the specific values have changed.