### PR TITLE
disable multiple tabs warning for PWA

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,6 +1,8 @@
 <Navbar isLoggedIn={$isAuthenticated} />
 <main>
-  <MultipleTabs />
+  {#if !isPwa()}
+    <MultipleTabs />
+  {/if}
   <Flash />
   <Router {routes} />
 </main>
@@ -17,6 +19,7 @@
   import Flash from './Flash.svelte'
   import Navbar from './Navbar.svelte'
   import MultipleTabs from './MultipleTabs.svelte'
+  import { isPwa } from './capabilities'
 
   const authenticate = async () => {
     if ($isAuthenticated === true) return true

--- a/client/src/capabilities.js
+++ b/client/src/capabilities.js
@@ -1,0 +1,5 @@
+export function isPwa() {
+  return matchMedia('(display-mode: standalone)').matches ||
+    navigator.standalone ||
+    document.referrer.includes('android-app://')
+}


### PR DESCRIPTION
When killing an app on mobile (by swiping it away) the `beforeunload` event is not called, and therefore the tab counter is not decreased. This leads to the warning to show up every time after that when starting the app.

Sidenote: The autosave warning (on unsaved changes) doesn't work either.

The detection code is taken from
https://stackoverflow.com/a/52695341/232838.

Fixes https://github.com/koffeinfrei/mykonote/issues/538